### PR TITLE
[hotfix] 유저 정보 수정 시 닉네임 중복 버그를 수정하고 로그아웃 시 인증 객체 정보를 제거한다.

### DIFF
--- a/src/main/java/com/dataracy/modules/common/util/CookieUtil.java
+++ b/src/main/java/com/dataracy/modules/common/util/CookieUtil.java
@@ -135,6 +135,46 @@ public class CookieUtil {
     }
 
     /**
+     * 지정한 이름의 쿠키를 삭제합니다.
+     * 쿠키를 삭제하기 위해 maxAge를 0으로 설정하고 빈 값을 설정합니다.
+     *
+     * @param request HTTP 요청 객체 (프로토콜 감지용)
+     * @param response HTTP 응답 객체
+     * @param name 삭제할 쿠키의 이름
+     */
+    public void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        boolean isSecure = isSecureEnvironment(request);
+        String sameSite = getSameSitePolicy(request);
+        String domain = getCookieDomain();
+        
+        ResponseCookie cookie = ResponseCookie.from(name, "")
+                .httpOnly(true)
+                .secure(isSecure)
+                .sameSite(sameSite)
+                .domain(domain)
+                .path("/")
+                .maxAge(Duration.ofSeconds(0))
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    /**
+     * 로그아웃 시 모든 인증 관련 쿠키를 삭제합니다.
+     * accessToken, refreshToken, accessTokenExpiration, refreshTokenExpiration, registerToken 쿠키를 모두 삭제합니다.
+     *
+     * @param request HTTP 요청 객체 (프로토콜 감지용)
+     * @param response HTTP 응답 객체
+     */
+    public void deleteAllAuthCookies(HttpServletRequest request, HttpServletResponse response) {
+        deleteCookie(request, response, "accessToken");
+        deleteCookie(request, response, "refreshToken");
+        deleteCookie(request, response, "accessTokenExpiration");
+        deleteCookie(request, response, "refreshTokenExpiration");
+        deleteCookie(request, response, "registerToken");
+    }
+
+    /**
      * HTTP 요청에서 "anonymousId" 쿠키 값을 반환하거나, 존재하지 않을 경우 새로 생성하여 응답에 설정한 후 반환합니다.
      *
      * @param request HTTP 요청 객체

--- a/src/main/java/com/dataracy/modules/user/adapter/jpa/impl/query/UserQueryDbAdapter.java
+++ b/src/main/java/com/dataracy/modules/user/adapter/jpa/impl/query/UserQueryDbAdapter.java
@@ -58,4 +58,12 @@ public class UserQueryDbAdapter implements UserQueryPort {
         LoggerFactory.db().logQueryEnd("UserEntity", "[findByEmail] 이메일로 유저 조회 종료 email=" + email, startTime);
         return userEntity.map(UserEntityMapper::toDomain);
     }
+
+    @Override
+    public Optional<String> findNicknameById(Long userId) {
+        Instant startTime = LoggerFactory.db().logQueryStart("UserEntity", "[findNicknameById] 유저 아이디로 닉네임 조회 시작 userId=" + userId);
+        Optional<String> nickname = userJpaRepository.findNicknameById(userId);
+        LoggerFactory.db().logQueryEnd("UserEntity", "[findNicknameById] 유저 아이디로 닉네임 조회 종료 userId=" + userId, startTime);
+        return nickname;
+    }
 }

--- a/src/main/java/com/dataracy/modules/user/adapter/jpa/repository/UserJpaRepository.java
+++ b/src/main/java/com/dataracy/modules/user/adapter/jpa/repository/UserJpaRepository.java
@@ -48,4 +48,6 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
     @Modifying
     @Query("UPDATE UserEntity u SET u.isDeleted = true WHERE u.id = :userId")
     void withdrawalUser(Long userId);
+
+    Optional<String> findNicknameById(Long id);
 }

--- a/src/main/java/com/dataracy/modules/user/adapter/web/api/command/UserCommandApi.java
+++ b/src/main/java/com/dataracy/modules/user/adapter/web/api/command/UserCommandApi.java
@@ -10,6 +10,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -75,13 +77,16 @@ public interface UserCommandApi {
 
     /**
      * 현재 로그인한 사용자의 세션과 리프레시 토큰을 무효화하여 로그아웃을 수행합니다.
+     * 모든 인증 관련 쿠키(accessToken, refreshToken, accessTokenExpiration, resetToken)를 삭제합니다.
      *
      * @param refreshToken 쿠키에 담긴 리프레시 토큰 — 해당 토큰을 무효화하여 로그아웃을 완료합니다.
+     * @param request HTTP 요청 객체 (쿠키 삭제용)
+     * @param response HTTP 응답 객체 (쿠키 삭제용)
      * @return 성공 응답을 담은 ResponseEntity(성공 시 본문은 비어있음)
      */
     @Operation(
             summary = "로그아웃",
-            description = "현재 로그인한 사용자의 세션 또는 RefreshToken을 무효화하고 로그아웃합니다.",
+            description = "현재 로그인한 사용자의 세션 또는 RefreshToken을 무효화하고 모든 인증 관련 쿠키를 삭제하여 로그아웃합니다.",
             security = {}
     )
     @ApiResponses(value = {
@@ -101,6 +106,12 @@ public interface UserCommandApi {
                     schema = @Schema(type = "string")
             )
             @CookieValue(value = "refreshToken")
-            String refreshToken
+            String refreshToken,
+
+            @Parameter(hidden = true)
+            HttpServletRequest request,
+
+            @Parameter(hidden = true)
+            HttpServletResponse response
     );
 }

--- a/src/main/java/com/dataracy/modules/user/application/port/out/query/UserQueryPort.java
+++ b/src/main/java/com/dataracy/modules/user/application/port/out/query/UserQueryPort.java
@@ -28,4 +28,6 @@ public interface UserQueryPort {
      * @return 해당 이메일을 가진 사용자가 존재하면 User를 포함한 Optional, 없으면 빈 Optional
      */
     Optional<User> findUserByEmail(String email);
+
+    Optional<String> findNicknameById(Long userId);
 }

--- a/src/main/java/com/dataracy/modules/user/application/service/command/content/UserCommandService.java
+++ b/src/main/java/com/dataracy/modules/user/application/service/command/content/UserCommandService.java
@@ -17,6 +17,7 @@ import com.dataracy.modules.user.application.dto.request.command.ModifyUserInfoR
 import com.dataracy.modules.user.application.port.in.command.command.LogoutUserUseCase;
 import com.dataracy.modules.user.application.port.in.command.command.ModifyUserInfoUseCase;
 import com.dataracy.modules.user.application.port.in.command.command.WithdrawUserUseCase;
+import com.dataracy.modules.security.handler.SecurityContextProvider;
 import com.dataracy.modules.user.application.port.in.validate.DuplicateNicknameUseCase;
 import com.dataracy.modules.user.application.port.out.command.UserCommandPort;
 import com.dataracy.modules.user.application.port.out.query.UserQueryPort;
@@ -210,6 +211,10 @@ public class UserCommandService implements
         }
 
         manageRefreshTokenUseCase.deleteRefreshToken(String.valueOf(userId));
+        
+        // SecurityContext의 인증 정보 삭제
+        SecurityContextProvider.clearSecurityContext();
+
         // 추후 고보안 서비스일 경우 어세스토큰 블랙리스트 처리까지 생각
 
         LoggerFactory.service().logSuccess("LogoutUserUseCase", "회원 로그아웃 서비스 성공 userId=" + userId, startTime);

--- a/src/main/java/com/dataracy/modules/user/application/service/command/content/UserCommandService.java
+++ b/src/main/java/com/dataracy/modules/user/application/service/command/content/UserCommandService.java
@@ -19,6 +19,10 @@ import com.dataracy.modules.user.application.port.in.command.command.ModifyUserI
 import com.dataracy.modules.user.application.port.in.command.command.WithdrawUserUseCase;
 import com.dataracy.modules.user.application.port.in.validate.DuplicateNicknameUseCase;
 import com.dataracy.modules.user.application.port.out.command.UserCommandPort;
+import com.dataracy.modules.user.application.port.out.query.UserQueryPort;
+import com.dataracy.modules.user.domain.exception.UserException;
+import com.dataracy.modules.user.domain.model.User;
+import com.dataracy.modules.user.domain.status.UserErrorStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,6 +39,7 @@ public class UserCommandService implements
         LogoutUserUseCase
 {
     private final UserCommandPort userCommandPort;
+    private final UserQueryPort userQueryPort;
 
     private final DuplicateNicknameUseCase duplicateNicknameUseCase;
     private final ValidateAuthorLevelUseCase validateAuthorLevelUseCase;
@@ -70,6 +75,7 @@ public class UserCommandService implements
 
         // 회원 정보 수정 요청 정보 유효성 검사
         validateModifyUserInfo(
+                userId,
                 requestDto.nickname(),
                 requestDto.authorLevelId(),
                 requestDto.occupationId(),
@@ -90,6 +96,7 @@ public class UserCommandService implements
      *
      * 요청된 프로필 이미지, 닉네임, 작성자 유형(필수), 선택적 직업·방문경로 및 토픽 ID들의 유효성을 확인합니다.
      *
+     * @param userId 로그인한 유저 아이디
      * @param nickname 수정할 닉네임(중복 검사 대상)
      * @param authorLevelId 필수인 작성자 유형 ID
      * @param occupationId 선택적 직업 ID(널이면 검사하지 않음)
@@ -98,6 +105,7 @@ public class UserCommandService implements
      * @param profileImageFile 업로드할 프로필 이미지 파일(널 또는 비어있지 않은 경우 이미지 형식 검사)
      */
     private void validateModifyUserInfo(
+            Long userId,
             String nickname,
             Long authorLevelId,
             Long occupationId,
@@ -108,8 +116,16 @@ public class UserCommandService implements
         // 프로필 이미지 파일 유효성 검사
         FileUtil.validateImageFile(profileImageFile);
 
-        // 닉네임 중복 체크
-        duplicateNicknameUseCase.validateDuplicatedNickname(nickname);
+        String savedNickname = userQueryPort.findNicknameById(userId)
+                .orElseThrow(() -> {
+                    LoggerFactory.service().logWarning("ModifyUserInfoUseCase", "[회원 정보 수정] 아이디에 해당하는 유저가 존재하지 않습니다. userId=" + userId);
+                    return new UserException(UserErrorStatus.NOT_FOUND_USER);
+                });
+
+        if (!savedNickname.equals(nickname)) {
+            // 닉네임 중복 체크
+            duplicateNicknameUseCase.validateDuplicatedNickname(nickname);
+        }
 
         // 작성자 유형 유효성 검사(필수 컬럼)
         validateAuthorLevelUseCase.validateAuthorLevel(authorLevelId);


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 유저 정보 수정 시 닉네임 중복 버그를 수정하고 로그아웃 시 인증 객체 정보를 제거한다.

---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #280 

---

## 🤖 자동 코드리뷰 시스템 적용 안내

리뷰는 한국어로 작성해주세요.

이 PR은 GPT-4 기반 코드리뷰 자동화 시스템을 적용합니다.

- PR 생성시 자동으로 리뷰 코멘트가 달립니다
- PR Summary는 `📦 PR 전체 요약`으로 표시됩니다
- 파일별 리뷰는 `🔍 아래 코멘트에 파일마다 커멘트로 달립니다.

📌 GPT 결과는 참고용이며, 반드시 수동 검토를 병행해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 로그아웃 시 모든 인증 쿠키가 자동으로 삭제되고 보안 컨텍스트가 초기화되어 완전한 로그아웃을 보장합니다.
  - 사용자 닉네임 단건 조회를 통해 프로필 수정 시 기존 닉네임과 동일한 경우 중복 검사를 자동으로 생략하여 더 빠르고 정확한 검증을 제공합니다.
  - 프로필 수정 검증이 방문 경로, 관심 토픽 등 선택 항목까지 포괄하도록 강화되었습니다.
- Documentation
  - 로그아웃 동작에 대한 쿠키 삭제 내용을 API 문서에 반영했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->