### PR TITLE
[hotfix] 회원 정보 수정 시 닉네임이 변경되었을 경우에만 분산락 처리를 구현한다.

### DIFF
--- a/src/main/java/com/dataracy/modules/user/adapter/jpa/repository/UserJpaRepository.java
+++ b/src/main/java/com/dataracy/modules/user/adapter/jpa/repository/UserJpaRepository.java
@@ -49,5 +49,12 @@ public interface UserJpaRepository extends JpaRepository<UserEntity, Long> {
     @Query("UPDATE UserEntity u SET u.isDeleted = true WHERE u.id = :userId")
     void withdrawalUser(Long userId);
 
+    /**
+     * 주어진 사용자 ID로 닉네임만 조회합니다.
+     *
+     * @param id 조회할 사용자의 ID
+     * @return 해당 사용자의 닉네임, 존재하지 않으면 Optional.empty()
+     */
+    @Query("SELECT u.nickname FROM UserEntity u WHERE u.id = :id")
     Optional<String> findNicknameById(Long id);
 }


### PR DESCRIPTION
## ✅ PR 유형
어떤 변경 사항이 있었나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

---

## 📝 작업 내용
이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 회원 정보 수정 시 닉네임이 변경되었을 경우에만 분산락 처리를 구현한다.

---

## ✏️ 관련 이슈
본인이 작업한 내용이 어떤 Issue Number와 관련이 있는지만 작성해주세요

- Resolves : #280 

---

## 🤖 자동 코드리뷰 시스템 적용 안내

리뷰는 한국어로 작성해주세요.

이 PR은 GPT-4 기반 코드리뷰 자동화 시스템을 적용합니다.

- PR 생성시 자동으로 리뷰 코멘트가 달립니다
- PR Summary는 `📦 PR 전체 요약`으로 표시됩니다
- 파일별 리뷰는 `🔍 아래 코멘트에 파일마다 커멘트로 달립니다.

📌 GPT 결과는 참고용이며, 반드시 수동 검토를 병행해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 닉네임 변경 시 동시성 제어를 적용해 안전하게 변경되도록 개선.
- 버그 수정
  - 닉네임 중복으로 인한 드문 충돌/실패 상황을 방지.
- 리팩터
  - 사용자 정보 수정 흐름을 닉네임 변경 여부에 따라 잠금 경로/비잠금 경로로 분리해 안정성과 가독성 향상.
- 성능/사용성
  - 닉네임이 변하지 않는 프로필 수정은 잠금을 생략해 더 빠르게 처리.
  - 입력값 검증을 강화하여 잘못된 선택 항목(직업, 방문 경로, 토픽 등)을 사전에 차단.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->